### PR TITLE
Do not exit the program on failed API Calls, return an error instead

### DIFF
--- a/gorocket.go
+++ b/gorocket.go
@@ -36,18 +36,13 @@ func (c *Client) sendRequest(req *http.Request, v interface{}) error {
 
 	res, err := c.HTTPClient.Do(req)
 	if err != nil {
-		log.Fatal(err)
+		log.Println(err)
+		return err
 	}
 
 	defer res.Body.Close()
-	//	body, err := ioutil.ReadAll(res.Body)
-	//fmt.Println(string(body))
-	//if err != nil {
-	//	log.Fatal(err)
-	//}
 
 	resp := v
-
 	if err = json.NewDecoder(res.Body).Decode(&resp); err != nil {
 		return err
 	}

--- a/hooks.go
+++ b/hooks.go
@@ -40,7 +40,8 @@ func (c *Client) Hooks(msg *HookMessage, token string) (*HookResponse, error) {
 	req.Header.Set("Content-Type", "application/json; charset=utf-8")
 
 	if err != nil {
-		log.Fatal("Request error")
+		log.Println("Request error")
+		return nil, err
 	}
 
 	res, err := c.HTTPClient.Do(req)
@@ -48,7 +49,8 @@ func (c *Client) Hooks(msg *HookMessage, token string) (*HookResponse, error) {
 	defer res.Body.Close()
 
 	if err != nil {
-		log.Fatal(err)
+		log.Println(err)
+		return nil, err
 	}
 
 	resp := HookResponse{}


### PR DESCRIPTION
Using log.Fatal() calls os.Exit(1) after the log message is printed.
os.Exit cannot be catched and exits the program without giving the
user a chance to recover from the error.